### PR TITLE
chnaged analytics

### DIFF
--- a/src/components/MuscadineFooter.tsx
+++ b/src/components/MuscadineFooter.tsx
@@ -113,7 +113,7 @@ export default function MuscadineFooter() {
                 Documentation
               </a>
               <a 
-                href="https://curator.muscadine.io" 
+                href="https://analytics.muscadine.io" 
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="block text-sm text-gray-300 hover:text-white transition-colors duration-200"

--- a/src/components/MuscadineHome.tsx
+++ b/src/components/MuscadineHome.tsx
@@ -347,7 +347,7 @@ const MuscadineHome = () => {
         </div>
       </div>
 
-      {/* Analytics / Curator Section */}
+      {/* Analytics Section */}
       <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-hidden">
         <div className="absolute inset-0 bg-gray-900" 
              style={{ clipPath: 'polygon(0 10%, 100% 0%, 100% 100%, 0% 100%)' }}>
@@ -358,26 +358,26 @@ const MuscadineHome = () => {
         <div className="relative py-16 md:py-20 mt-12 md:mt-16">
           <div className="max-w-4xl mx-auto px-4 text-center">
             <h2 className="text-2xl sm:text-3xl font-light text-white mb-4 font-serif">
-              Analytics &amp; Curator
+              Analytics
             </h2>
             <p className="text-gray-200 leading-relaxed mb-6">
-              Explore metrics, dashboards, and curated insights at{' '}
+              Explore metrics and dashboards at{' '}
               <a 
-                href="https://curator.muscadine.io" 
+                href="https://analytics.muscadine.io" 
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="text-white font-medium underline underline-offset-2 hover:no-underline"
               >
-                curator.muscadine.io
+                analytics.muscadine.io
               </a>
             </p>
             <a 
-              href="https://curator.muscadine.io" 
+              href="https://analytics.muscadine.io" 
               target="_blank" 
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center px-6 py-3 bg-white text-gray-900 font-semibold rounded-lg hover:bg-gray-100 transition-colors text-sm"
             >
-              Open Curator
+              Open Analytics
               <svg className="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
               </svg>

--- a/src/components/SolutionsPage.tsx
+++ b/src/components/SolutionsPage.tsx
@@ -111,29 +111,29 @@ const SolutionsPage = () => {
 
         </div>
 
-        {/* Analytics / Curator Section */}
+        {/* Analytics Section */}
         <div className="mt-12 py-8 px-6 rounded-lg border-2 border-gray-200 text-center">
           <h3 className="text-xl font-light text-gray-900 mb-3 font-serif">
-            Analytics &amp; Curator
+            Analytics
           </h3>
           <p className="text-gray-600 text-sm leading-relaxed max-w-xl mx-auto mb-4">
-            Explore metrics, dashboards, and curated insights at{' '}
+            Explore metrics and dashboards at{' '}
             <a 
-              href="https://curator.muscadine.io" 
+              href="https://analytics.muscadine.io" 
               target="_blank" 
               rel="noopener noreferrer"
               className="text-blue-600 hover:text-blue-700 font-medium"
             >
-              curator.muscadine.io
+              analytics.muscadine.io
             </a>
           </p>
           <a 
-            href="https://curator.muscadine.io" 
+            href="https://analytics.muscadine.io" 
             target="_blank" 
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center px-5 py-2.5 border-2 border-gray-300 text-gray-900 font-medium rounded-lg hover:bg-gray-900 hover:text-white hover:border-gray-900 transition-all duration-300 text-sm"
           >
-            Open Curator
+            Open Analytics
             <svg className="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
             </svg>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: copy and outbound link updates only; main risk is broken navigation if the new analytics URL is incorrect.
> 
> **Overview**
> Updates the site’s **Analytics** references to point to `https://analytics.muscadine.io` instead of `https://curator.muscadine.io`.
> 
> Renames UI copy in the Home and Solutions Analytics sections from “Analytics & Curator” / “Open Curator” to “Analytics” / “Open Analytics”, and updates the footer Resources link accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1932ab1afdb9f026419b2522aa82abea761e3436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->